### PR TITLE
add Sec-CH-UA-Platform-Version support

### DIFF
--- a/lib/HTTP/UserAgentClientHints.pm
+++ b/lib/HTTP/UserAgentClientHints.pm
@@ -17,6 +17,7 @@ my @FIELDS = qw/
     Model
     Full-Version-List
     Full-Version
+    Platform-Version
 /;
 
 # Build getters
@@ -159,6 +160,10 @@ To get the value of Sec-CH-UA-Mobile
 
 To get the value of Sec-CH-UA-Platform
 
+=head3 platform_version
+
+To get the value of Sec-CH-UA-Platform-Version
+
 =head3 arch
 
 To get the value of Sec-CH-UA-Arch
@@ -179,6 +184,7 @@ To get the value of Sec-CH-UA-Full-Version-List as an object of L<HTTP::UserAgen
 
 To get the value of Sec-CH-UA-Full-Version
 
+
 =head2 Getters for Sec-CH-UA* raw values
 
 =head3 ua_raw
@@ -186,6 +192,8 @@ To get the value of Sec-CH-UA-Full-Version
 =head3 mobile_raw
 
 =head3 platform_raw
+
+=head3 platform_version_raw
 
 =head3 arch_raw
 

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -9,6 +9,7 @@ my $h = HTTP::Headers->new(
     'Sec-CH-UA' => q|"Chrome"; v="73", "Chromium"; v="73", "?Not:Your Browser"; v="11"|,
     'Sec-CH-UA-Mobile' => q|?1|,
     'Sec-CH-UA-Platform' => q|"Windows"|,
+    'Sec-CH-UA-Platform-Version' => q|10|,
     'Sec-CH-UA-Arch' => q|"arm"|,
     'Sec-CH-UA-Bitness' => q|"64"|,
     'Sec-CH-UA-Model' => q|"Pixel 2 XL"|,
@@ -29,6 +30,7 @@ RAW: {
     t->got($uach->ua_raw)->expected(q|"Chrome"; v="73", "Chromium"; v="73", "?Not:Your Browser"; v="11"|)->is;
     t->got($uach->mobile_raw)->expected(q|?1|)->is;
     t->got($uach->platform_raw)->expected(q|"Windows"|)->is;
+    t->got($uach->platform_version_raw)->expected(q|10|)->is;
     t->got($uach->arch_raw)->expected(q|"arm"|)->is;
     t->got($uach->bitness_raw)->expected(q|"64"|)->is;
     t->got($uach->model_raw)->expected(q|"Pixel 2 XL"|)->is;
@@ -44,6 +46,7 @@ RAW: {
     t->got($uach->ua->brand_version->{Chromium})->expected(73)->is;
     t->got($uach->mobile)->expected(q|1|)->is;
     t->got($uach->platform)->expected(q|Windows|)->is;
+    t->got($uach->platform_version)->expected(q|10|)->is;
     t->got($uach->arch)->expected(q|arm|)->is;
     t->got($uach->bitness)->expected(q|64|)->is;
     t->got($uach->model)->expected(q|Pixel 2 XL|)->is;
@@ -56,9 +59,9 @@ RAW: {
 }
 
 ACCEPT_CH: {
-    t->got($uach->accept_ch)->expected('Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Model, Sec-CH-UA-Full-Version-List, Sec-CH-UA-Full-Version')->is;
-    t->got($uach->accept_ch([qw/Sec-CH-UA-Full-Version/]))->expected('Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Model, Sec-CH-UA-Full-Version-List')->is;
-    t->got($uach->accept_ch([qw/Sec-CH-UA-Full-Version Sec-CH-UA-Bitness/]))->expected('Sec-CH-UA-Arch, Sec-CH-UA-Model, Sec-CH-UA-Full-Version-List')->is;
+    t->got($uach->accept_ch)->expected('Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Model, Sec-CH-UA-Full-Version-List, Sec-CH-UA-Full-Version, Sec-CH-UA-Platform-Version')->is;
+    t->got($uach->accept_ch([qw/Sec-CH-UA-Full-Version/]))->expected('Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Model, Sec-CH-UA-Full-Version-List, Sec-CH-UA-Platform-Version')->is;
+    t->got($uach->accept_ch([qw/Sec-CH-UA-Full-Version Sec-CH-UA-Bitness/]))->expected('Sec-CH-UA-Arch, Sec-CH-UA-Model, Sec-CH-UA-Full-Version-List, Sec-CH-UA-Platform-Version')->is;
 }
 
 EDGE_CASES: {
@@ -73,11 +76,13 @@ EDGE_CASES: {
     t->got($uach->ua_raw)->expected(undef)->is;
     t->got($uach->mobile_raw)->expected('')->is;
     t->got($uach->platform_raw)->expected(0)->is;
+    t->got($uach->platform_version_raw)->expected(undef)->is;
     t->got($uach->arch_raw)->expected(undef)->is;
 
     t->got($uach->ua)->expected(undef)->is;
     t->got($uach->mobile)->expected('')->is;
     t->got($uach->platform)->expected(0)->is;
+    t->got($uach->platform_version)->expected(undef)->is;
     t->got($uach->arch)->expected(undef)->is;
 }
 


### PR DESCRIPTION
`Sec-CH-UA-Platform-Version` ヘッダーを読み出す `platform_version`と`platform_version_raw`を追加してみました。
よかったら取り込んでいただけるとうれしいです。